### PR TITLE
Adding paging support for getPlaylistItemsByPlaylistId

### DIFF
--- a/src/Alaouy/Youtube/Youtube.php
+++ b/src/Alaouy/Youtube/Youtube.php
@@ -262,16 +262,28 @@ class Youtube {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function getPlaylistItemsByPlaylistId($playlistId, $maxResults = 50) {
+	public function getPlaylistItemsByPlaylistId($playlistId, $pageToken = false, $maxResults = 50) {
 		$API_URL = $this->getApi('playlistItems.list');
 		$params = array(
 			'playlistId' => $playlistId,
 			'part' => 'id, snippet, contentDetails, status',
 			'maxResults' => $maxResults,
 		);
+
+		// Pass page token if it is given, an empty string won't change the api response
+		if(is_string($pageToken)) {
+			$params['pageToken'] = $pageToken;
+		}
 		$apiData = $this->api_get($API_URL, $params);
-		return $this->decodeList($apiData);
+		$result =['data' => $this->decodeList($apiData)];
+
+		if(is_string($pageToken) || $pageToken) {
+			$result['nextPage'] = (isset($this->page_info['nextPageToken']) ? $this->page_info['nextPageToken'] : false );
+			$result['prevPage'] = (isset($this->page_info['prevPageToken']) ? $this->page_info['prevPageToken'] : false );
+		}
+		return $result;
 	}
+
 
 	/**
 	 * @param $channelId

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -176,8 +176,9 @@ class YoutubeTest extends \PHPUnit_Framework_TestCase {
 		$GOOGLE_ZEITGEIST_PLAYLIST = 'PL590L5WQmH8fJ54F369BLDSqIwcs-TCfs';
 		$response = $this->youtube->getPlaylistItemsByPlaylistId( $GOOGLE_ZEITGEIST_PLAYLIST );
 
-		$this->assertTrue( count( $response ) > 0 );
-		$this->assertEquals( 'youtube#playlistItem', $response[0]->kind );
+		$data = $response['data'];
+		$this->assertTrue( count( $data ) > 0 );
+		$this->assertEquals( 'youtube#playlistItem', $data[0]->kind );
 	}
 
 	public function testParseVIdFromURLFull() {


### PR DESCRIPTION
Youtube::getPlaylistItemsByPlaylistId didn't provide a means for paging results, which makes it impossible to view playlists with more than 50 videos.