### PR TITLE
replaced service container's deprecated bindShared() with singleton()

### DIFF
--- a/src/Alaouy/Youtube/YoutubeServiceProvider.php
+++ b/src/Alaouy/Youtube/YoutubeServiceProvider.php
@@ -48,7 +48,7 @@ class YoutubeServiceProvider extends ServiceProvider
 
         $this->publishes(array(__DIR__ . '/../../config/youtube.php' => config_path('youtube.php')));
 
-        $this->app->bindShared('youtube', function () {
+        $this->app->singleton('youtube', function () {
             return $this->app->make('Alaouy\Youtube\Youtube', [config('youtube.KEY')]);
         });
     }


### PR DESCRIPTION
As you can read in the [release notes of Laravel 5.1.0](https://laravel.com/docs/master/upgrade#upgrade-5.1.0), the "service container's bindShared method has been deprecated in favor of the singleton method". It got removed as announced "with the release of Laravel 5.2 in December 2015".