### PR TITLE
Laravel 5.4 make method fix

### DIFF
--- a/src/Alaouy/Youtube/YoutubeServiceProvider.php
+++ b/src/Alaouy/Youtube/YoutubeServiceProvider.php
@@ -49,7 +49,11 @@ class YoutubeServiceProvider extends ServiceProvider
         $this->publishes(array(__DIR__ . '/../../config/youtube.php' => config_path('youtube.php')));
 
         //Laravel 5.1+ fix
-        if(floatval(Application::VERSION) >= 5.1){
+        if (floatval(Application::VERSION) >= 5.4) {
+            $this->app->bind("youtube", function(){
+                return new Youtube(config('youtube.KEY'));
+            });
+        } elseif(floatval(Application::VERSION) >= 5.1) {
             $this->app->bind("youtube", function(){
                 return $this->app->make('Alaouy\Youtube\Youtube', [config('youtube.KEY')]);
             });


### PR DESCRIPTION
In Laravel 5.4 the make method no longer accepts a second parameter.
This commit will fixes this.