### PR TITLE
Add ability to list videos in a users channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ $videoList = Youtube::searchVideos('Android');
 // Search only videos in a given channel, return an array of PHP objects
 $videoList = Youtube::searchChannelVideos('keyword', 'UCk1SpWNzOs4MYmr0uICEntg', 40);
 
+// List videos in a given channel, return an array of PHP objects
+$videoList = Youtube::listChannelVideos('UCk1SpWNzOs4MYmr0uICEntg', 40);
+
 $results = Youtube::searchAdvanced(array( /* params */ ));
 
 // Get channel data by channel name, return an STD PHP object

--- a/src/Alaouy/Youtube/Youtube.php
+++ b/src/Alaouy/Youtube/Youtube.php
@@ -162,6 +162,31 @@ class Youtube
     }
 
     /**
+     * List videos in the channel
+     *
+     * @param  string $channelId
+     * @param  integer $maxResults
+     * @param  string $order
+     * @param  array $part
+     * @param  $pageInfo
+     * @return array
+     */
+    public function listChannelVideos($channelId, $maxResults = 10, $order = null, $part = ['id', 'snippet'], $pageInfo = false)
+    {
+        $params = array(
+            'type' => 'video',
+            'channelId' => $channelId,
+            'part' => implode(', ', $part),
+            'maxResults' => $maxResults,
+        );
+        if (!empty($order)) {
+            $params['order'] = $order;
+        }
+
+        return $this->searchAdvanced($params, $pageInfo);
+    }
+
+    /**
      * Generic Search interface, use any parameters specified in
      * the API reference
      *
@@ -174,8 +199,8 @@ class Youtube
     {
         $API_URL = $this->getApi('search.list');
 
-        if (empty($params) || !isset($params['q'])) {
-            throw new \InvalidArgumentException('at least the Search query must be supplied');
+        if (empty($params) || (!isset($params['q']) && !isset($params['channelId']))) {
+            throw new \InvalidArgumentException('at least the Search query or Channel ID must be supplied');
         }
 
         $apiData = $this->api_get($API_URL, $params);

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -139,6 +139,15 @@ class YoutubeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('youtube#video', $response[0]->id->kind);
     }
 
+    public function testListChannelVideos()
+    {
+        $limit = rand(3, 10);
+        $response = $this->youtube->listChannelVideos('UCVHFbqXqoYvEWM1Ddxl0QDg', $limit);
+        $this->assertEquals($limit, count($response));
+        $this->assertEquals('youtube#searchResult', $response[0]->kind);
+        $this->assertEquals('youtube#video', $response[0]->id->kind);
+    }
+
     public function testSearchAdvanced()
     {
         //TODO


### PR DESCRIPTION
Checks for channelId and q parameter for empty search, and adds a method to list the videos on a users channel. includes a basic test.