### PR TITLE
Properly capitalize 'YouTube'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Youtube
+YouTube
 =========
 
-![Travis Youtube Build](https://api.travis-ci.org/alaouy/Youtube.svg?branch=master)
+![Travis YouTube Build](https://api.travis-ci.org/alaouy/Youtube.svg?branch=master)
 
-Laravel PHP Facade/Wrapper for the Youtube Data API v3 ( Non-OAuth )
+Laravel PHP Facade/Wrapper for the YouTube Data API v3 ( Non-OAuth )
 
 ## Requirements
 
@@ -11,7 +11,7 @@ Laravel PHP Facade/Wrapper for the Youtube Data API v3 ( Non-OAuth )
 - Laravel 5.1 or higher
 - API key from [Google Console](https://console.developers.google.com)
 
-Looking for Youtube Package for either of these: PHP 5, Laravel 5.0, Laravel 4? Visit the [`php5-branch`](https://github.com/alaouy/Youtube/tree/php5)
+Looking for YouTube Package for either of these: PHP 5, Laravel 5.0, Laravel 4? Visit the [`php5-branch`](https://github.com/alaouy/Youtube/tree/php5)
 
 ## Installation
 
@@ -22,22 +22,22 @@ composer require alaouy/youtube
 
 ## Configuration
 
-In `/config/app.php` add YoutubeServiceProvider:
+In `/config/app.php` add YouTubeServiceProvider:
 ```
-Alaouy\Youtube\YoutubeServiceProvider::class,
+Alaouy\YouTube\YouTubeServiceProvider::class,
 ```
 
-Do not forget to add also Youtube facade there:
+Do not forget to add also YouTube facade there:
 ```
-'Youtube' => Alaouy\Youtube\Facades\Youtube::class,
+'YouTube' => Alaouy\YouTube\Facades\YouTube::class,
 ```
 
 Publish config settings:
 ```
-$ php artisan vendor:publish --provider="Alaouy\Youtube\YoutubeServiceProvider"
+$ php artisan vendor:publish --provider="Alaouy\YouTube\YouTubeServiceProvider"
 ```
 
-Set your Youtube API key in the file:
+Set your YouTube API key in the file:
 
 ```
 /config/youtube.php
@@ -47,54 +47,54 @@ Set your Youtube API key in the file:
 ## Usage
 
 ```php
-// use Alaouy\Youtube\Facades\Youtube;
+// use Alaouy\YouTube\Facades\YouTube;
 
 // Return an STD PHP object
-$video = Youtube::getVideoInfo('rie-hPVJ7Sw');
+$video = YouTube::getVideoInfo('rie-hPVJ7Sw');
 
 // Get multiple videos info from an array
-$videoList = Youtube::getVideoInfo(['rie-hPVJ7Sw','iKHTawgyKWQ']);
+$videoList = YouTube::getVideoInfo(['rie-hPVJ7Sw','iKHTawgyKWQ']);
 
 // Get multiple videos related to a video
-$relatedVideos = Youtube::getRelatedVideos('iKHTawgyKWQ');
+$relatedVideos = YouTube::getRelatedVideos('iKHTawgyKWQ');
 
 // Get popular videos in a country, return an array of PHP objects
-$videoList = Youtube::getPopularVideos('us');
+$videoList = YouTube::getPopularVideos('us');
 
 // Search playlists, channels and videos. return an array of PHP objects
-$results = Youtube::search('Android');
+$results = YouTube::search('Android');
 
 // Only search videos, return an array of PHP objects
-$videoList = Youtube::searchVideos('Android');
+$videoList = YouTube::searchVideos('Android');
 
 // Search only videos in a given channel, return an array of PHP objects
-$videoList = Youtube::searchChannelVideos('keyword', 'UCk1SpWNzOs4MYmr0uICEntg', 40);
+$videoList = YouTube::searchChannelVideos('keyword', 'UCk1SpWNzOs4MYmr0uICEntg', 40);
 
 // List videos in a given channel, return an array of PHP objects
-$videoList = Youtube::listChannelVideos('UCk1SpWNzOs4MYmr0uICEntg', 40);
+$videoList = YouTube::listChannelVideos('UCk1SpWNzOs4MYmr0uICEntg', 40);
 
-$results = Youtube::searchAdvanced([ /* params */ ]);
+$results = YouTube::searchAdvanced([ /* params */ ]);
 
 // Get channel data by channel name, return an STD PHP object
-$channel = Youtube::getChannelByName('xdadevelopers');
+$channel = YouTube::getChannelByName('xdadevelopers');
 
 // Get channel data by channel ID, return an STD PHP object
-$channel = Youtube::getChannelById('UCk1SpWNzOs4MYmr0uICEntg');
+$channel = YouTube::getChannelById('UCk1SpWNzOs4MYmr0uICEntg');
 
 // Get playlist by ID, return an STD PHP object
-$playlist = Youtube::getPlaylistById('PL590L5WQmH8fJ54F369BLDSqIwcs-TCfs');
+$playlist = YouTube::getPlaylistById('PL590L5WQmH8fJ54F369BLDSqIwcs-TCfs');
 
 // Get playlist by channel ID, return an array of PHP objects
-$playlists = Youtube::getPlaylistsByChannelId('UCk1SpWNzOs4MYmr0uICEntg');
+$playlists = YouTube::getPlaylistsByChannelId('UCk1SpWNzOs4MYmr0uICEntg');
 
 // Get items in a playlist by playlist ID, return an array of PHP objects
-$playlistItems = Youtube::getPlaylistItemsByPlaylistId('PL590L5WQmH8fJ54F369BLDSqIwcs-TCfs');
+$playlistItems = YouTube::getPlaylistItemsByPlaylistId('PL590L5WQmH8fJ54F369BLDSqIwcs-TCfs');
 
 // Get channel activities by channel ID, return an array of PHP objects
-$activities = Youtube::getActivitiesByChannelId('UCk1SpWNzOs4MYmr0uICEntg');
+$activities = YouTube::getActivitiesByChannelId('UCk1SpWNzOs4MYmr0uICEntg');
 
 // Retrieve video ID from original YouTube URL
-$videoId = Youtube::parseVidFromURL('https://www.youtube.com/watch?v=moSFlvxnbgk');
+$videoId = YouTube::parseVidFromURL('https://www.youtube.com/watch?v=moSFlvxnbgk');
 // result: moSFlvxnbgk
 ```
 
@@ -110,7 +110,7 @@ $params = [
 ];
 
 // Make intial call. with second argument to reveal page info such as page tokens
-$search = Youtube::searchAdvanced($params, true);
+$search = YouTube::searchAdvanced($params, true);
 
 // Check if we have a pageToken
 if (isset($search['info']['nextPageToken'])) {
@@ -118,7 +118,7 @@ if (isset($search['info']['nextPageToken'])) {
 }
 
 // Make another call and repeat
-$search = Youtube::searchAdvanced($params, true);
+$search = YouTube::searchAdvanced($params, true);
 
 // Add results key with info parameter set
 print_r($search['results']);
@@ -137,25 +137,25 @@ $params = [
 $pageTokens = [];
 
 // Make inital search
-$search = Youtube::paginateResults($params, null);
+$search = YouTube::paginateResults($params, null);
 
 // Store token
 $pageTokens[] = $search['info']['nextPageToken'];
 
 // Go to next page in result
-$search = Youtube::paginateResults($params, $pageTokens[0]);
+$search = YouTube::paginateResults($params, $pageTokens[0]);
 
 // Store token
 $pageTokens[] = $search['info']['nextPageToken'];
 
 // Go to next page in result
-$search = Youtube::paginateResults($params, $pageTokens[1]);
+$search = YouTube::paginateResults($params, $pageTokens[1]);
 
 // Store token
 $pageTokens[] = $search['info']['nextPageToken'];
 
 // Go back a page
-$search = Youtube::paginateResults($params, $pageTokens[0]);
+$search = YouTube::paginateResults($params, $pageTokens[0]);
 
 // Add results key with info parameter set
 print_r($search['results']);
@@ -182,8 +182,8 @@ The returned JSON is decoded as PHP objects (not Array).
 Please read the ["Reference" section](https://developers.google.com/youtube/v3/docs/) of the Official API doc.
 
 
-## Youtube Data API v3
-- [Youtube Data API v3 Doc](https://developers.google.com/youtube/v3/)
+## YouTube Data API v3
+- [YouTube Data API v3 Doc](https://developers.google.com/youtube/v3/)
 - [Obtain API key from Google API Console](https://console.developers.google.com)
 
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "alaouy/youtube",
-  "description": "Laravel PHP Facade/Wrapper for the Youtube Data API v3",
+  "description": "Laravel PHP Facade/Wrapper for the YouTube Data API v3",
   "keywords": ["youtube", "api", "video", "laravel", "alaouy"],
   "license": "MIT",
   "authors": [
@@ -17,21 +17,21 @@
   },
   "autoload": {
     "psr-4": {
-      "Alaouy\\Youtube\\": "src"
+      "Alaouy\\YouTube\\": "src"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Alaouy\\Youtube\\Tests\\": "tests"
+      "Alaouy\\YouTube\\Tests\\": "tests"
     }
   },
   "extra": {
     "laravel": {
       "providers": [
-        "Alaouy\\Youtube\\YoutubeServiceProvider"
+        "Alaouy\\YouTube\\YouTubeServiceProvider"
       ],
       "aliases": {
-        "Youtube": "Alaouy\\Youtube\\Facades\\Youtube"
+        "YouTube": "Alaouy\\YouTube\\Facades\\YouTube"
       }
     }
   }

--- a/src/Facades/YouTube.php
+++ b/src/Facades/YouTube.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Alaouy\Youtube\Facades;
+namespace Alaouy\YouTube\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class Youtube extends Facade {
+class YouTube extends Facade {
 
     /**
      * Get the registered name of the component.

--- a/src/YouTube.php
+++ b/src/YouTube.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Alaouy\Youtube;
+namespace Alaouy\YouTube;
 
-class Youtube
+class YouTube
 {
 
     /**
@@ -30,7 +30,7 @@ class Youtube
 
     /**
      * Constructor
-     * $youtube = new Youtube(['key' => 'KEY HERE'])
+     * $youtube = new YouTube(['key' => 'KEY HERE'])
      *
      * @param string $key
      * @throws \Exception
@@ -457,7 +457,7 @@ class Youtube
             $vid = substr($path, 1);
             return $vid;
         } else {
-            throw new \Exception('The supplied URL does not look like a Youtube URL');
+            throw new \Exception('The supplied URL does not look like a YouTube URL');
         }
     }
 
@@ -471,7 +471,7 @@ class Youtube
     public function getChannelFromURL($youtube_url)
     {
         if (strpos($youtube_url, 'youtube.com') === false) {
-            throw new \Exception('The supplied URL does not look like a Youtube URL');
+            throw new \Exception('The supplied URL does not look like a YouTube URL');
         }
 
         $path = static::_parse_url_path($youtube_url);
@@ -484,7 +484,7 @@ class Youtube
             $username = $segments[count($segments) - 1];
             $channel = $this->getChannelByName($username);
         } else {
-            throw new \Exception('The supplied URL does not look like a Youtube Channel URL');
+            throw new \Exception('The supplied URL does not look like a YouTube Channel URL');
         }
 
         return $channel;
@@ -509,7 +509,7 @@ class Youtube
      *
      * @param  string $apiData the api response from youtube
      * @throws \Exception
-     * @return \StdClass  an Youtube resource object
+     * @return \StdClass  an YouTube resource object
      */
     public function decodeSingle(&$apiData)
     {
@@ -536,7 +536,7 @@ class Youtube
      *
      * @param  string $apiData the api response from youtube
      * @throws \Exception
-     * @return \StdClass  an Youtube resource object
+     * @return \StdClass  an YouTube resource object
      */
     public function decodeMultiple(&$apiData)
     {

--- a/src/YouTubeServiceProvider.php
+++ b/src/YouTubeServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Alaouy\Youtube;
+namespace Alaouy\YouTube;
 
 use Illuminate\Support\ServiceProvider;
 
-class YoutubeServiceProvider extends ServiceProvider
+class YouTubeServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application events.
@@ -24,7 +24,7 @@ class YoutubeServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->bind('youtube', function () {
-            return new Youtube(config('youtube.key'));
+            return new YouTube(config('youtube.key'));
         });
     }
 
@@ -35,6 +35,6 @@ class YoutubeServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return [Youtube::class];
+        return [YouTube::class];
     }
 }

--- a/src/config/youtube.php
+++ b/src/config/youtube.php
@@ -2,10 +2,10 @@
 
 /*
 |--------------------------------------------------------------------------
-| Laravel PHP Facade/Wrapper for the Youtube Data API v3
+| Laravel PHP Facade/Wrapper for the YouTube Data API v3
 |--------------------------------------------------------------------------
 |
-| Here is where you can set your key for Youtube API. In case you do not
+| Here is where you can set your key for YouTube API. In case you do not
 | have it, it can be acquired from: https://console.developers.google.com
 */
 

--- a/tests/YouTubeTest.php
+++ b/tests/YouTubeTest.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Alaouy\Youtube\Tests;
+namespace Alaouy\YouTube\Tests;
 
-use Alaouy\Youtube\Youtube;
+use Alaouy\YouTube\YouTube;
 use PHPUnit\Framework\TestCase;
 
-class YoutubeTest extends TestCase
+class YouTubeTest extends TestCase
 {
     const TEST_API_KEY = 'AIzaSyDDefsgXEZu57wYgABF7xEURClu4UAzyB8';
 
-    /** @var Youtube */
+    /** @var YouTube */
     public $youtube;
 
     public function setUp()
     {
-        $this->youtube = new Youtube(self::TEST_API_KEY);
+        $this->youtube = new YouTube(self::TEST_API_KEY);
     }
 
     public function tearDown()
@@ -35,7 +35,7 @@ class YoutubeTest extends TestCase
      */
     public function testConstructorFail()
     {
-        $this->youtube = new Youtube(array());
+        $this->youtube = new YouTube(array());
     }
 
     /**
@@ -43,7 +43,7 @@ class YoutubeTest extends TestCase
      */
     public function testConstructorFail2()
     {
-        $this->youtube = new Youtube('');
+        $this->youtube = new YouTube('');
     }
 
     /**
@@ -51,7 +51,7 @@ class YoutubeTest extends TestCase
      */
     public function testInvalidApiKey()
     {
-        $this->youtube = new Youtube(array('key' => 'nonsense'));
+        $this->youtube = new YouTube(array('key' => 'nonsense'));
         $vID = 'rie-hPVJ7Sw';
         $this->youtube->getVideoInfo($vID);
     }


### PR DESCRIPTION
YouTube's [brand guidelines](https://www.youtube.com/yt/about/brand-resources/#logos-icons-colors) specify that their name is spelled "YouTube", not "Youtube".

![screenshot](https://i.imgur.com/5rGnyAz.png)