### PR TITLE
Laravel 4 fix for publishing package config in boot

### DIFF
--- a/src/Alaouy/Youtube/YoutubeServiceProvider.php
+++ b/src/Alaouy/Youtube/YoutubeServiceProvider.php
@@ -28,7 +28,10 @@ class YoutubeServiceProvider extends ServiceProvider
 
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('Youtube', 'Alaouy\Youtube\Facades\Youtube');
-        $this->publishes(array(__DIR__ . '/../../config/youtube.php' => config_path('youtube.php')));
+
+        if (!$this->isLegacyLaravel() && !$this->isOldLaravel()) {
+            $this->publishes(array(__DIR__ . '/../../config/youtube.php' => config_path('youtube.php')));
+        }
     }
 
     /**


### PR DESCRIPTION
Check laravel version before calling `$this->publishes`, as it does not exist in laravel 4