### PR TITLE
Allowing to set API key programmatically

### DIFF
--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -45,6 +45,25 @@ class Youtube
     }
 
     /**
+     * @param $key
+     * @return Youtube
+     */
+    public function setApiKey($key)
+    {
+        $this->youtube_key = $key;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getApiKey()
+    {
+        return $this->youtube_key;
+    }
+
+    /**
      * @param $regionCode
      * @return \StdClass
      * @throws \Exception

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -46,6 +46,13 @@ class YoutubeTest extends TestCase
         $this->youtube = new Youtube('');
     }
 
+    public function testSetApiKey()
+    {
+        $this->youtube->setApiKey('new_api_key');
+
+        $this->assertEquals($this->youtube->getApiKey(), 'new_api_key');
+    }
+
     /**
      * @expectedException \Exception
      */


### PR DESCRIPTION
Added setApiKey() and getApiKey() in case a web app allows user to set the API key via web interface instead of config file.