### PR TITLE
New function to get localized video info

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ $video = Youtube::getVideoInfo('rie-hPVJ7Sw');
 // Get multiple videos info from an array
 $videoList = Youtube::getVideoInfo(['rie-hPVJ7Sw','iKHTawgyKWQ']);
 
+// Get localized video info
+$video = Youtube::getLocalizedVideoInfo('vjF9GgrY9c0', 'pl');
+
 // Get multiple videos related to a video
 $relatedVideos = Youtube::getRelatedVideos('iKHTawgyKWQ');
 

--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -155,6 +155,36 @@ class Youtube
 
         return $this->decodeSingle($apiData);
     }
+    
+    /**
+     * Gets localized video info by language (f.ex. de) by adding this parameter after video id
+     * Youtube::getLocalizedVideoInfo($video->url, 'de')
+     *
+     * @param $vId
+     * @param $language
+     * @param array $part
+     * @return \StdClass
+     * @throws \Exception
+     */
+
+    public function getLocalizedVideoInfo($vId, $language, $part = ['id', 'snippet', 'contentDetails', 'player', 'statistics', 'status']) {
+
+        $API_URL = $this->getApi('videos.list');
+        $params = [
+            'id'    => is_array($vId) ? implode(',', $vId) : $vId,
+            'key' => $this->youtube_key,
+            'hl'    =>  $language,
+            'part' => implode(', ', $part),
+        ];
+
+        $apiData = $this->api_get($API_URL, $params);
+
+        if (is_array($vId)) {
+            return $this->decodeMultiple($apiData);
+        }
+
+        return $this->decodeSingle($apiData);
+    }
 
     /**
      * Gets popular videos for a specific region (ISO 3166-1 alpha-2)

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -103,6 +103,23 @@ class YoutubeTest extends TestCase
         $this->assertObjectHasAttribute('snippet', $response);
         $this->assertObjectHasAttribute('contentDetails', $response);
     }
+    
+    public function testGetLocalizedVideoInfo()
+    {
+        $videoId = 'vjF9GgrY9c0';
+        $language = 'pl';
+
+        $response = $this->youtube->getLocalizedVideoInfo($videoId, $language);
+
+        $this->assertNotNull('response');
+        $this->assertEquals('youtube#video', $response->kind);
+        //add all these assertions here in case the api is changed,
+        //we can detect it instantly
+        $this->assertObjectHasAttribute('statistics', $response);
+        $this->assertObjectHasAttribute('status', $response);
+        $this->assertObjectHasAttribute('snippet', $response);
+        $this->assertObjectHasAttribute('contentDetails', $response);
+    }
 
     public function testGetVideoInfoMultiple()
     {


### PR DESCRIPTION
This new function gets localized video info (YouTube provides translating title and description). If it isn't avaliable, automatically returns info in default language.

You can use it by calling the Youtube::getLocalizedVideoInfo($video->url, $language) and then normally get data.