### PR TITLE
Update method parseVidFromURL to have proper capitalization

### DIFF
--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -560,7 +560,7 @@ class Youtube
      * @throws \Exception
      * @return string Video Id
      */
-    public static function parseVIdFromURL($youtube_url)
+    public static function parseVidFromURL($youtube_url)
     {
         if (strpos($youtube_url, 'youtube.com')) {
             if (strpos($youtube_url, 'embed')) {


### PR DESCRIPTION
simply change I to i to have valid naming capitalization to match documentation and assist in unit testing. Fixes #134