### PR TITLE
Mismatch: parseVIdFromURL vs parseVidFromURL

### DIFF
--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -560,7 +560,7 @@ class Youtube
      * @throws \Exception
      * @return string Video Id
      */
-    public static function parseVIdFromURL($youtube_url)
+    public static function parseVidFromURL($youtube_url)
     {
         if (strpos($youtube_url, 'youtube.com')) {
             if (strpos($youtube_url, 'embed')) {


### PR DESCRIPTION
Line 563: public static function parseVIdFromURL($youtube_url)

Shouldn't this be: parseVidFromURL($youtube_url) ?

OR is it VId as in Video Id? It just doesn't match usage example, that's all.