### PR TITLE
Add ext-curl to list of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     }
   ],
   "require": {
-    "php": "^7.0"
+    "php": "^7.0",
+    "ext-curl": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.1"


### PR DESCRIPTION
Missing PHP extension `curl` should be detected on installation.

```
$ composer require alaouy/youtube
Using version ^2.2 for alaouy/youtube
./composer.json has been updated
Running composer update alaouy/youtube
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking alaouy/youtube (v2.2.4)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing alaouy/youtube (v2.2.4): Extracting archive
[..]
```

```
$ php artisan tinker
Psy Shell v0.10.4 (PHP 7.4.12 — cli) by Justin Hileman
>>> Youtube::getChannelById('UCcdNy_FqMi0z1VU6kanOvFQ')
PHP Error:  Call to undefined function Alaouy/Youtube/curl_init() in REDACTED/vendor/alaouy/youtube/src/Youtube.php on line 738
```