### PR TITLE
Add videoCategoryId param to getPopularVideos

### DIFF
--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -238,7 +238,7 @@ class Youtube
      * @param array $part
      * @return array
      */
-    public function getPopularVideos($regionCode, $videoCategoryId = 0, $maxResults = 10, $part = ['id', 'snippet', 'contentDetails', 'player', 'statistics', 'status'])
+    public function getPopularVideos($regionCode, $maxResults = 10, $part = ['id', 'snippet', 'contentDetails', 'player', 'statistics', 'status'], $videoCategoryId = 0)
     {
         $API_URL = $this->getApi('videos.list');
         $params = [

--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -238,13 +238,14 @@ class Youtube
      * @param array $part
      * @return array
      */
-    public function getPopularVideos($regionCode, $maxResults = 10, $part = ['id', 'snippet', 'contentDetails', 'player', 'statistics', 'status'])
+    public function getPopularVideos($regionCode, $videoCategoryId = 0, $maxResults = 10, $part = ['id', 'snippet', 'contentDetails', 'player', 'statistics', 'status'])
     {
         $API_URL = $this->getApi('videos.list');
         $params = [
             'chart' => 'mostPopular',
             'part' => implode(',', $part),
             'regionCode' => $regionCode,
+            'videoCategoryId' => $videoCategoryId,
             'maxResults' => $maxResults,
         ];
 

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -139,7 +139,8 @@ class YoutubeTest extends TestCase
     {
         $maxResult = rand(10, 30);
         $regionCode = 'us';
-        $response = $this->youtube->getPopularVideos($regionCode, $maxResult);
+        $videoCategoryId = 0;
+        $response = $this->youtube->getPopularVideos($regionCode, $videoCategoryId, $maxResult);
 
         $this->assertNotNull('response');
         $this->assertEquals($maxResult, count($response));

--- a/tests/YoutubeTest.php
+++ b/tests/YoutubeTest.php
@@ -140,7 +140,8 @@ class YoutubeTest extends TestCase
         $maxResult = rand(10, 30);
         $regionCode = 'us';
         $videoCategoryId = 0;
-        $response = $this->youtube->getPopularVideos($regionCode, $videoCategoryId, $maxResult);
+        $part = ['id', 'snippet', 'contentDetails', 'player', 'statistics', 'status'];
+        $response = $this->youtube->getPopularVideos($regionCode, $maxResult, $part, $videoCategoryId);
 
         $this->assertNotNull('response');
         $this->assertEquals($maxResult, count($response));


### PR DESCRIPTION
Adding the `videoCategoryId` parameter to `getPopularVideos` method. This allows the user to get results based on categories specified here:

[https://mixedanalytics.com/blog/list-of-youtube-video-category-ids](https://mixedanalytics.com/blog/list-of-youtube-video-category-ids)